### PR TITLE
fix: ItemDetails routing

### DIFF
--- a/src/frontend/app/ItemDetails.tsx
+++ b/src/frontend/app/ItemDetails.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import { View, Text } from "react-native";
 
-export default function ItemDetails() {
+const ItemDetails = () => {
   return (
     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
       <Text>Item details</Text>
     </View>
   );
-}
+};
+
+export default ItemDetails;

--- a/src/frontend/components/SingleItem.tsx
+++ b/src/frontend/components/SingleItem.tsx
@@ -46,13 +46,13 @@ const SingleItem = ({ item, source }: Props) => {
     if (source === "myItems") {
       setShowFavoritesIcon(false);
       router.push({
-        pathname: "../app/ItemDetails",
+        pathname: "/ItemDetails",
         params: { item: JSON.stringify(item), source: source },
       });
     } else {
       setShowFavoritesIcon(true);
       router.push({
-        pathname: "../app/ItemDetails",
+        pathname: "/ItemDetails",
         params: { item: JSON.stringify(item) },
       });
     }


### PR DESCRIPTION
There was a problem with routing to the ItemDetails page. When the user clicks the SingleItem component, it previously sent the user to ../app/ItemDetails which gave a page not found error