### PR TITLE
fix AppInitializer -> purchase request bug

### DIFF
--- a/src/frontend/app/_layout.tsx
+++ b/src/frontend/app/_layout.tsx
@@ -6,6 +6,7 @@ import "react-native-reanimated";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { AuthProvider } from "./contexts/AuthContext";
 import React from "react";
+import { AppInitialier } from "@/components/AppInitializer";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -38,6 +39,7 @@ export default function RootLayout() {
 
   return (
     <AuthProvider>
+      <AppInitialier />
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="(auth)" options={{ headerShown: false }} />


### PR DESCRIPTION
I fixed the purchase request bug. When the user clicked the purchase request nothing, it gave an error cause it wasn't getting the user data. Now it also shows the purchase modal and sends the purchase request to the seller